### PR TITLE
Fix H-Sync pin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Your VGA connector requires five wires:
 * Pin 6: Red Return - connect to GND
 * Pin 7: Green Return - connect to GND
 * Pin 8: Blue Return - connect to GND
-* Pin 13: H-Sync - connect to PB6
+* Pin 13: H-Sync - connect to PB4
 * Pin 14: V-Sync - connect to PC4
 
 The resistive divider needs to drop the 3.3V output down to 0.7V. Some


### PR DESCRIPTION
The monotron I have in front of me has H-Sync (pin 13) connected to PB4, and it worked all weekend. The code also says PB4, so unless I'm misunderstanding something, the README is wrong.